### PR TITLE
Update package.json to support ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "webpack-dev-server": "^3.11.0"
   },
+  "module": "./lib/matestack/ui/bootstrap/index.js",
   "exports": {
     ".": "./lib/matestack/ui/bootstrap/index.js"
   }


### PR DESCRIPTION
With this in place, we can now use matestack-ui-bootstrap as an ES Module, and ultimately, with [importmap-rails[(https://github.com/rails/importmap-rails).

I followed the suggestion [outlined in Skypack's documentation](https://docs.skypack.dev/package-authors/package-checks#esm) as the path of least resistance.