### PR TITLE
Add Webpacker configuration to avoid using ESM packages on Dummy app

### DIFF
--- a/spec/dummy/config/webpack/environment.js
+++ b/spec/dummy/config/webpack/environment.js
@@ -6,7 +6,9 @@ const webpack = require('webpack');
 const customWebpackConfig = {
   resolve: {
     alias: {
-      'vue': 'vue/dist/vue.esm-bundler'
+      'vue': 'vue/dist/vue.esm-bundler',
+      'matestack-ui-vuejs': 'matestack-ui-vuejs/lib/matestack/ui/vue_js/index.js',
+      'matestack-ui-bootstrap': 'matestack-ui-bootstrap/lib/matestack/ui/bootstrap/index.js'
     }
   },
   plugins: [


### PR DESCRIPTION
## Issue 30 https://github.com/matestack/matestack-ui-bootstrap/issues/30: Gem's stylesheets not loaded by Dummy app

### Changes
As stated in the installation docs for matestack-ui-bootstrap, we need to have webpacker not use the ESM package and let it know which directories to build from (in this case, from the gem's own index.js export).

- [x] Add aliases to specify where to resolve `matestack-ui-vuejs` and `matestack-ui-bootstrap` from.
